### PR TITLE
Install certbot-auto dependencies from Chef run

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,13 +4,15 @@ driver:
 
 provisioner:
   name: chef_solo
+  require_chef_omnibus: '12' # some dependent cookbooks aren't Chef 13 ready
 
 platforms:
   - name: ubuntu-14.04
-  - name: centos-7.1
+  - name: ubuntu-16.04
+  - name: centos-6.9
+  - name: centos-7.3
 
 suites:
   - name: default
     run_list:
       - recipe[certbot::default]
-    attributes:

--- a/recipes/create-sandbox.rb
+++ b/recipes/create-sandbox.rb
@@ -34,6 +34,7 @@ end
   directory path do
     owner node['certbot']['sandbox']['user']
     group node['certbot']['sandbox']['group']
+    recursive true
   end
   execute "chown #{path}" do
     command "chown -R #{node['certbot']['sandbox']['user']}:#{node['certbot']['sandbox']['group']} #{path}"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -26,4 +26,7 @@ when 'certbot-auto'
     source 'https://dl.eff.org/certbot-auto'
     mode 0755
   end
+
+  # run certbot-auto to install its dependencies
+  execute "'#{node['certbot']['bin']}' --os-packages-only --non-interactive"
 end

--- a/recipes/server-webroots.rb
+++ b/recipes/server-webroots.rb
@@ -1,4 +1,6 @@
-directory node['certbot']['sandbox']['webroot_path']
+directory node['certbot']['sandbox']['webroot_path'] do
+  recursive true
+end
 
 template "#{node['nginx']['dir']}/certbot.conf" do
   source 'certbot-nginx.conf.erb'


### PR DESCRIPTION
So they are ready and available ahead of certbot execution

Also allow tests to pass when no webroot exists